### PR TITLE
(Azure CXP) Updated Regex at line 105 

### DIFF
--- a/src/Modules/Security/Windows/Install/InstallSecurityAgent.ps1
+++ b/src/Modules/Security/Windows/Install/InstallSecurityAgent.ps1
@@ -102,7 +102,7 @@ function UpdateSecurityConfiguration
     $authenticationConfigPath = "$PSScriptRoot\..\Authentication.config"
 	[System.Xml.Linq.XDocument]$authenticationXmlDoc = [System.Xml.Linq.XDocument]::Load($authenticationConfigPath)
 
-	$filePath = if($FilePath -match "^[a-zA-Z]:\*") {$FilePath} else {"$($PWD.path)\$($FilePath)"}
+	$filePath = if($FilePath -match "^[a-zA-Z]:\\.*") {$FilePath} else {"$($PWD.path)\$($FilePath)"}
 	if(!(Test-Path -path $filePath)){
 		throw "File $($filePath) does not exist!"
 	}


### PR DESCRIPTION
Updated Regular expression to make sure that the absolute path expression defined in the if statement works. currently if we run the script , it works only if the certificate file is moved to a relative path or same working directory as the script so in the below expression if condition is never true and only the else condition gets evaluated. 

Changed the following at line 105 
`	$filePath = if($FilePath -match "^[a-zA-Z]:\*") {$FilePath} else {"$($PWD.path)\$($FilePath)"}
`
to 
`     $filePath = if($FilePath -match "^[a-zA-Z]:\\.*") {$FilePath} else {"$($PWD.path)\$($FilePath)"}
`

In the statement absolute path does not work and only relative path works as complained by the customer on the Github issue MicrosoftDocs/azure-docs#51943 . If we change the regex in the script as above , it will be fixed. Hence requesting an update in the script . 

Thank you.